### PR TITLE
github: create coverage reports

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,3 +35,16 @@ jobs:
         with:
           command: clippy
           args: -- --deny warnings
+  coverage:
+    name: LNDK Code Coverage
+    runs-on: ubuntu-latest
+    env:
+      CARGO_TERM_COLOR: always
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Rust
+        run: rustup update stable
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,3 +48,8 @@ jobs:
         uses: taiki-e/install-action@cargo-llvm-cov
       - name: Generate code coverage
         run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          files: lcov.info
+          fail_ci_if_error: true


### PR DESCRIPTION
Uses the example from:
https://github.com/taiki-e/cargo-llvm-cov

Uploads results to Codecov.io (requires adding the Github App to your repo)